### PR TITLE
fix trx times

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -73,7 +73,7 @@ map_data$url[grepl('trx', map_data$stid)] <- 'https://air.utah.edu/s/measurement
 map_data$durl[grepl('trx', map_data$stid)] <- 'https://air.utah.edu/s/diagnostics/'
 map_data$popup <- paste0(
   '<b>', map_data$name, '</b>', ' (', toupper(map_data$stid), ')<br>',
-  strftime(data$Time_UTC, tz = 'America/Denver', format = '%b %d %I:%M %p %Z<br>'),
+  strftime(map_data$Time_UTC, tz = 'America/Denver', format = '%b %d %I:%M %p %Z<br>'),
   ifelse(is.na(map_data$CO2d_ppm), '',
          paste0('CO<sub>2</sub>&emsp;<b>', map_data$CO2d_ppm, ' ppm</b><br>')),
   ifelse(is.na(map_data$CH4d_ppm), '',


### PR DESCRIPTION
trx times were pulling from data (fixed sites) instead of from map_data, this made all the trx bubbles look like they were from about the same time.